### PR TITLE
whereis.bat conflicts with GnuWin32's whereis.exe

### DIFF
--- a/scripts/add2virtualenv.bat
+++ b/scripts/add2virtualenv.bat
@@ -26,7 +26,7 @@ if not defined WORKON_HOME (
 if defined PYTHONHOME (
     goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/cdsitepackages.bat
+++ b/scripts/cdsitepackages.bat
@@ -7,7 +7,7 @@ if not defined WORKON_HOME (
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/cdvirtualenv.bat
+++ b/scripts/cdvirtualenv.bat
@@ -7,7 +7,7 @@ if not defined WORKON_HOME (
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/lssitepackages.bat
+++ b/scripts/lssitepackages.bat
@@ -7,7 +7,7 @@ if not defined WORKON_HOME (
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/mkvirtualenv.bat
+++ b/scripts/mkvirtualenv.bat
@@ -21,7 +21,7 @@ if defined VIRTUAL_ENV (
 if defined PYTHONHOME (
 	goto HOMEOK
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 :HOMEOK
 

--- a/scripts/pyassoc.bat
+++ b/scripts/pyassoc.bat
@@ -7,7 +7,7 @@ if defined VIRTUAL_ENV (
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/python.bat
+++ b/scripts/python.bat
@@ -3,7 +3,7 @@
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN

--- a/scripts/toggleglobalsitepackages.bat
+++ b/scripts/toggleglobalsitepackages.bat
@@ -3,7 +3,7 @@
 if defined PYTHONHOME (
 	goto MAIN
 )
-FOR /F "tokens=*" %%i in ('whereis python.exe') do set PYTHONHOME=%%~dpi
+FOR /F "tokens=*" %%i in ('whereis.bat python.exe') do set PYTHONHOME=%%~dpi
 SET PYTHONHOME=%PYTHONHOME:~0,-1%
 
 :MAIN


### PR DESCRIPTION
Those who installed GnuWin32 have a whereis.exe in their PATH that conflicts with your whereis.bat. On my machine, whereis.exe was getting priority and being called in place of your whereis.bat.

```
C:\Users\shaneallgeier>where whereis
C:\gnuwin32\bin\whereis.exe
C:\Python27\Scripts\whereis.bat
```

The problem is that whereis.exe's output is not compatible with your whereis.bat, which caused the following error:

```
C:\Users\shaneallgeier>mkvirtualenv test
The system cannot find the path specified.
The system cannot find the path specified.
The system cannot find the path specified.
```

The fix would be to rename your whereis.bat to something else. Perhaps just where.bat since you seem to be duplicating that program's output anyways.
