### PR TITLE
Avoid breaking when usernames contain shell metacharacters.

### DIFF
--- a/scripts/add2virtualenv.bat
+++ b/scripts/add2virtualenv.bat
@@ -20,7 +20,7 @@ goto END
 
 :ADD2
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined PYTHONHOME (

--- a/scripts/cdsitepackages.bat
+++ b/scripts/cdsitepackages.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined PYTHONHOME (

--- a/scripts/cdvirtualenv.bat
+++ b/scripts/cdvirtualenv.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined PYTHONHOME (

--- a/scripts/lssitepackages.bat
+++ b/scripts/lssitepackages.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined PYTHONHOME (

--- a/scripts/lsvirtualenv.bat
+++ b/scripts/lsvirtualenv.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
     
 :LIST

--- a/scripts/mkvirtualenv.bat
+++ b/scripts/mkvirtualenv.bat
@@ -11,7 +11,7 @@ goto END
 
 :MKVIRTUALENV
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined VIRTUAL_ENV (

--- a/scripts/rmvirtualenv.bat
+++ b/scripts/rmvirtualenv.bat
@@ -11,7 +11,7 @@ goto END
 
 :RMVIRTUALENV
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if defined VIRTUAL_ENV (

--- a/scripts/setprojectdir.bat
+++ b/scripts/setprojectdir.bat
@@ -15,7 +15,7 @@ goto SETPROJECTDIR
 
 
 	if not defined WORKON_HOME (
-		set WORKON_HOME=%USERPROFILE%\Envs
+		set "WORKON_HOME=%USERPROFILE%\Envs"
 	)
 	
 	if not defined VIRTUALENVWRAPPER_PROJECT_FILENAME (

--- a/scripts/workon.bat
+++ b/scripts/workon.bat
@@ -5,7 +5,7 @@ if defined VIRTUAL_ENV (
 )
 
 if not defined WORKON_HOME (
-    set WORKON_HOME=%USERPROFILE%\Envs
+    set "WORKON_HOME=%USERPROFILE%\Envs"
 )
 
 if not defined VIRTUALENVWRAPPER_PROJECT_FILENAME (


### PR DESCRIPTION
Without this, if you have a username like `User (test)`, the commands in question just fail with a message like `\Envs was unexpected at this time.`
