### PR TITLE
Fixed changeing dir when using workon without project dir set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 virtualenvwrapper-win
 =====================
 
-This is a port of Doug Hellmann's `virtualenvwrapper <http://www.doughellmann.com/projects/virtualenvwrapper/>`_ 
-to Windows batch scripts. The idea behind virtualenvwrapper is to ease usage of 
-Ian Bicking's `virtualenv <http://pypi.python.org/pypi/virtualenv>`_, a tool 
-for creating isolated Python virtual environments, each with their own libraries 
+This is a port of Doug Hellmann's `virtualenvwrapper <http://www.doughellmann.com/projects/virtualenvwrapper/>`_
+to Windows batch scripts. The idea behind virtualenvwrapper is to ease usage of
+Ian Bicking's `virtualenv <http://pypi.python.org/pypi/virtualenv>`_, a tool
+for creating isolated Python virtual environments, each with their own libraries
 and site-packages.
 
-These scripts should work on any version of Windows (Windows XP, Windows Vista, Windows 7/8). 
+These scripts should work on any version of Windows (Windows XP, Windows Vista, Windows 7/8).
 
-However, they only work in the **regular command prompt**. They **will not work in Powershell.** There are other virtualenvwrapper projects out there for Powershell. 
+However, they only work in the **regular command prompt**. They **will not work in Powershell.** There are other virtualenvwrapper projects out there for Powershell.
 
 
 Installation
@@ -25,7 +25,7 @@ To install, run one of the following::
 
     # using easy_install
     easy_install virtualenvwrapper-win
-    
+
     # from source
     git clone git://github.com/davidmarble/virtualenvwrapper-win.git
     cd virtualenvwrapper-win
@@ -40,7 +40,7 @@ If you use several versions of python, you can switch between them using a separ
 Main Commands
 -------------
 ``mkvirtualenv <name>``
-    Create a new virtualenv environment named *<name>*.  The environment will 
+    Create a new virtualenv environment named *<name>*.  The environment will
     be created in WORKON_HOME.
 
 ``lsvirtualenv``
@@ -50,68 +50,69 @@ Main Commands
     Remove the environment *<name>*. Uses ``folder_delete.bat``.
 
 ``workon [<name>]``
-    If *<name>* is specified, activate the environment named *<name>* (change 
-    the working virtualenv to *<name>*). If a project directory has been 
-    defined, we will change into it. If no argument is specified, list the 
-    available environments. 
+    If *<name>* is specified, activate the environment named *<name>* (change
+    the working virtualenv to *<name>*). If a project directory has been
+    defined, we will change into it. If no argument is specified, list the
+    available environments. One can pass additional option -c after
+    virtualenv name to cd to virtualenv directory if no projectdir is set.
 
 ``deactivate``
-    Deactivate the working virtualenv and switch back to the default system 
+    Deactivate the working virtualenv and switch back to the default system
     Python.
 
 ``add2virtualenv <full or relative path>``
-    If a virtualenv environment is active, appends *<path>* to 
+    If a virtualenv environment is active, appends *<path>* to
     ``virtualenv_path_extensions.pth`` inside the environment's site-packages,
-    which effectively adds *<path>* to the environment's PYTHONPATH. 
+    which effectively adds *<path>* to the environment's PYTHONPATH.
     If a virtualenv environment is not active, appends *<path>* to
-    ``virtualenv_path_extensions.pth`` inside the default Python's 
+    ``virtualenv_path_extensions.pth`` inside the default Python's
     site-packages. If *<path>* doesn't exist, it will be created.
-    
+
 Convenience Commands
 --------------------
 ``cdproject``
     If a virtualenv environment is active and a projectdir has been defined,
     change the current working directory to active virtualenv's project directory.
-    ``cd-`` will return you to the last directory you were in before calling 
+    ``cd-`` will return you to the last directory you were in before calling
     ``cdproject``.
 
 ``cdsitepackages``
-    If a virtualenv environment is active, change the current working 
-    directory to the active virtualenv's site-packages directory. If 
-    a virtualenv environment is not active, change the current working 
-    directory to the default Python's site-packages directory. ``cd-`` 
-    will return you to the last directory you were in before calling 
+    If a virtualenv environment is active, change the current working
+    directory to the active virtualenv's site-packages directory. If
+    a virtualenv environment is not active, change the current working
+    directory to the default Python's site-packages directory. ``cd-``
+    will return you to the last directory you were in before calling
     ``cdsitepackages``.
 
 ``cdvirtualenv``
-    If a virtualenv environment is active, change the current working 
-    directory to the active virtualenv base directory. If a virtualenv 
-    environment is not active, change the current working directory to 
-    the base directory of the default Python. ``cd-`` will return you 
+    If a virtualenv environment is active, change the current working
+    directory to the active virtualenv base directory. If a virtualenv
+    environment is not active, change the current working directory to
+    the base directory of the default Python. ``cd-`` will return you
     to the last directory you were in before calling ``cdvirtualenv``.
 
 ``lssitepackages``
-    If a virtualenv environment is active, list that environment's 
-    site-packages. If a virtualenv environment is not active, list the 
-    default Python's site-packages. Output includes a basic listing of 
-    the site-packages directory, the contents of easy-install.pth, 
-    and the contents of virtualenv_path_extensions.pth (used by 
+    If a virtualenv environment is active, list that environment's
+    site-packages. If a virtualenv environment is not active, list the
+    default Python's site-packages. Output includes a basic listing of
+    the site-packages directory, the contents of easy-install.pth,
+    and the contents of virtualenv_path_extensions.pth (used by
     ``add2virtualenv``).
 
 ``setprojectdir <full or relative path>``
-    If a virtualenv environment is active, define *<path>* as project 
+    If a virtualenv environment is active, define *<path>* as project
     directory containing the source code.  This allows the use of ``cdproject``
-    to change the working directory. In addition, the directory will be 
-    added to the environment using ``add2virtualenv``. If *<path>* doesn't 
+    to change the working directory. In addition, the directory will be
+    added to the environment using ``add2virtualenv``. If *<path>* doesn't
     exist, it will be created.
 
 ``toggleglobalsitepackages``
-    If a virtualenv environment is active, toggle between having the 
+    If a virtualenv environment is active, toggle between having the
     global site-packages in the PYTHONPATH or just the virtualenv's
     site-packages.
 
 ``whereis <file>``
-    A script included for convenience. Returns directory locations 
-    of `file` and `file` with any executable extensions. So you can call 
-    ``whereis python`` to find all executables starting with ``python`` or 
+    A script included for convenience. Returns directory locations
+    of `file` and `file` with any executable extensions. So you can call
+    ``whereis python`` to find all executables starting with ``python`` or
     ``whereis python.exe`` for an exact match.

--- a/scripts/workon.bat
+++ b/scripts/workon.bat
@@ -19,6 +19,20 @@ dir /b /ad "%WORKON_HOME%"
 goto END
 
 :WORKON
+
+set VENV=%1
+shift
+
+:LOOP
+if not "%1"=="" (
+    if "%1"=="-c" (
+        SET CHANGEDIR=1
+        shift
+    )
+    shift
+    goto :LOOP
+)
+
 if defined VIRTUAL_ENV (
     call "%VIRTUAL_ENV%\Scripts\deactivate.bat"
 )
@@ -28,31 +42,33 @@ if errorlevel 1 (
     mkdir "%WORKON_HOME%"
 )
 
-pushd "%WORKON_HOME%\%1" 2>NUL && popd
+pushd "%WORKON_HOME%\%VENV%" 2>NUL && popd
 if errorlevel 1 (
     echo.
-    echo.    virtualenv "%1" does not exist.
+    echo.    virtualenv "%VENV%" does not exist.
     echo.    Create it with "mkvirtualenv %1"
     goto END
 )
 
-if not exist "%WORKON_HOME%\%1\Scripts\activate.bat" (
+if not exist "%WORKON_HOME%\%VENV%\Scripts\activate.bat" (
     echo.
-    echo.    %WORKON_HOME%\%1
+    echo.    %WORKON_HOME%\%VENV%
     echo.    doesn't contain a virtualenv ^(yet^).
-    echo.    Create it with "mkvirtualenv %1"
+    echo.    Create it with "mkvirtualenv %VENV%"
     goto END
 )
 
-call "%WORKON_HOME%\%1\Scripts\activate.bat"
+call "%WORKON_HOME%\%VENV%\Scripts\activate.bat"
 if defined WORKON_OLDTITLE (
     title %1 ^(VirtualEnv^)
 )
 
-if exist "%WORKON_HOME%\%1\%VIRTUALENVWRAPPER_PROJECT_FILENAME%" (
+if exist "%WORKON_HOME%\%VENV%\%VIRTUALENVWRAPPER_PROJECT_FILENAME%" (
     call cdproject.bat
 ) else (
-    cd /d "%WORKON_HOME%\%1"
+    if %CHANGEDIR%==1(
+        cd /d "%WORKON_HOME%\%VENV%"
+    )
 )
 
 :END

--- a/scripts/workon.bat
+++ b/scripts/workon.bat
@@ -58,15 +58,13 @@ if not exist "%WORKON_HOME%\%VENV%\Scripts\activate.bat" (
     goto END
 )
 
-call "%WORKON_HOME%\%VENV%\Scripts\activate.bat"
 if defined WORKON_OLDTITLE (
     title %1 ^(VirtualEnv^)
 )
-
 if exist "%WORKON_HOME%\%VENV%\%VIRTUALENVWRAPPER_PROJECT_FILENAME%" (
     call cdproject.bat
 ) else (
-    if %CHANGEDIR%==1(
+    if "%CHANGEDIR%"=="1" (
         cd /d "%WORKON_HOME%\%VENV%"
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ except IOError:
 
 PYTHONHOME = sys.exec_prefix
 
+
 class install(_setuptools_install):
+
     def run(self):
         # pre-install
         _setuptools_install.run(self)
@@ -57,7 +59,7 @@ class install(_setuptools_install):
                 fname = f.strip()
                 for script in scripts:
                     if fname.endswith(script):
-                        newname = fname.replace('Scripts\\','')
+                        newname = fname.replace('Scripts\\', '')
                         # try:
                         #     os.remove(dst)
                         # except:
@@ -82,7 +84,7 @@ setup(
     license="BSD 3-clause",
     keywords="setuptools deployment installation distutils virtualenv virtualenvwrapper",
 
-    platforms=['WIN32', 'WIN64',],
+    platforms=['WIN32', 'WIN64', ],
 
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -105,7 +107,7 @@ setup(
 
     scripts=[scripts_loc + script for script in scripts],
 
-    install_requires=['virtualenv',],
+    install_requires=['virtualenv', ],
 
     # extras
     # pywin==0.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = 'David Marble'
 EMAIL = 'davidmarble@gmail.com'
 DESCRIPTION = ('Port of Doug Hellmann\'s virtualenvwrapper '
                'to Windows batch scripts')
-VERSION = '1.1.6'
+VERSION = '1.1.7'
 PROJECT_URL = 'https://github.com/davidmarble/%s/' % (PROJECT)
 scripts_loc = 'scripts/'
 scripts = [
@@ -106,7 +106,7 @@ setup(
     scripts=[scripts_loc + script for script in scripts],
 
     install_requires=['virtualenv',],
-    
+
     # extras
     # pywin==0.2
 


### PR DESCRIPTION
As @denissss mention in issue #48. Version 1.1.7 changed how workon behave. I've added option "-c" to workon. Only it -c is passed to workon the dir is changed:

workon venv -c -> changes dir if no project dir is set
workon venv     -> don't change dir (default)