### PR TITLE
Puts the scripts back in the script directory...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ PYTHONHOME = sys.exec_prefix
 
 
 setup(
-    # cmdclass={'install': install},
     name=PROJECT,
     version=VERSION,
 

--- a/setup.py
+++ b/setup.py
@@ -50,34 +50,8 @@ except IOError:
 PYTHONHOME = sys.exec_prefix
 
 
-class install(_setuptools_install):
-
-    def run(self):
-        # pre-install
-        _setuptools_install.run(self)
-        # post-install
-        # Re-write install-record to take into account new file locations
-        if self.record:
-            newlist = []
-            with codecs.open(self.record, 'r', 'utf-8') as f:
-                files = f.readlines()
-            for f in files:
-                fname = f.strip()
-                for script in scripts:
-                    if fname.endswith(script):
-                        newname = fname.replace('Scripts\\', '')
-                        # try:
-                        #     os.remove(dst)
-                        # except:
-                        #     pass
-                        shutil.move(fname, newname)
-                        fname = newname
-                newlist.append(fname)
-            with codecs.open(self.record, 'w', 'utf-8') as f:
-                f.write('\n'.join(newlist))
-
 setup(
-    cmdclass={'install': install},
+    # cmdclass={'install': install},
     name=PROJECT,
     version=VERSION,
 


### PR DESCRIPTION
For your consideration.

Not backwards compatible, in that users without the scripts directory in the path with have to put it there to continue using virtualenvwrapper-win, but more standard and will allow it to work in multi-python environments (see http://testerstories.com/2014/06/multiple-versions-of-python-on-windows/ for discussion).