### PR TITLE
Fix cleanup when running rmvirtualenv command

### DIFF
--- a/scripts/rmvirtualenv.bat
+++ b/scripts/rmvirtualenv.bat
@@ -41,10 +41,10 @@ if exist "%WORKON_HOME%\%1\%VIRTUALENVWRAPPER_PROJECT_FILENAME%" (
 
 call folder_delete.bat *
 cd ..
-rmdir "%1"
+rmdir "%1" /s /q
 cd /d "%_CURRDIR%"
 echo.
-echo.    Deleted %WORKON_HOME%\%1 
+echo.    Deleted %WORKON_HOME%\%1
 echo.
 
 set _CURRDIR=


### PR DESCRIPTION
This fixes #55 by adding switches to rmdir command to ensure any extra files in the root folder are deleted when cleaning up.