### PR TITLE
add project_path option to mkvirtualenv

### DIFF
--- a/scripts/mkvirtualenv.bat
+++ b/scripts/mkvirtualenv.bat
@@ -28,7 +28,7 @@ for /f "usebackq tokens=*" %%a in (`python.exe -c "import sys;print(sys.exec_pre
 :MAIN
 REM Copy all arguments, then set ENVNAME to the last argument
 set "ARGS=%*"
-call :GET_ENVNAME %*
+call :GET_OPTIONS %*
 
 pushd "%WORKON_HOME%" 2>NUL && popd
 if errorlevel 1 (
@@ -47,9 +47,9 @@ REM As of Python 2.7, calling virtualenv.exe causes a new window to open,
 REM so call the script directly
 REM recent versions of virtualenv does not contain virtualenv-script.py..
 if exist "%PYHOME%\Scripts\virtualenv-script.py" (
-   python.exe "%PYHOME%\Scripts\virtualenv-script.py" %ARGS%
+   python.exe "%PYHOME%\Scripts\virtualenv-script.py" %ENVNAME%
 ) else (
-  virtualenv.exe %ARGS%
+  virtualenv.exe %ENVNAME%
 )
 popd
 if errorlevel 2 goto END
@@ -74,24 +74,31 @@ REM In deactivate.bat, reset PYTHONPATH to its former value
 )
 
 call "%WORKON_HOME%\%ENVNAME%\Scripts\activate.bat"
+if not "%PROJECTDIR%"=="" call setprojectdir.bat "%PROJECTDIR%"
 
 REM Run postmkvirtualenv.bat
 
 if defined VIRTUALENVWRAPPER_HOOK_DIR (
     if exist "%VIRTUALENVWRAPPER_HOOK_DIR%\postmkvirtualenv.bat" (
-    	call "%VIRTUALENVWRAPPER_HOOK_DIR%\postmkvirtualenv.bat"
+        call "%VIRTUALENVWRAPPER_HOOK_DIR%\postmkvirtualenv.bat"
     )
 )
 
 
 goto END
 
-:GET_ENVNAME
-  set "ENVNAME=%~1"
-  shift
-  if not "%~1"=="" goto GET_ENVNAME
+:GET_OPTIONS
+    if /I not "%~1"=="-a" (
+        set "ENVNAME=%~1"
+        shift
+    ) else (
+        shift & set PROJECTDIR=?
+    )
+    if "%PROJECTDIR%"=="?" set "PROJECTDIR=%~1"
+    if not "%~1"=="" goto GET_OPTIONS
 goto :eof
 
 :END
 set PYHOME=
 set ENVNAME=
+set PROJECTDIR=


### PR DESCRIPTION
Add the -a project_path option to the mkvirtualenv wrapper in order
to allow the user to set the project dir (by automatically invoking
the setprojectdir script) when creating the virtual environment.

This brings the wrapper closer to offering one to one feature
parity with the Linux virtualenvwrapper script.

This is part of the implementation required for closing #60 
