### PR TITLE
Implement -a, -i, and -r options to mkvirtualenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 Include
 Lib
 virtualenvwrapper_win.egg-info
+tests/logfile.txt

--- a/devenv.bat
+++ b/devenv.bat
@@ -1,0 +1,7 @@
+@echo off
+::
+:: Add scripts and tests directory to front of path.
+::
+set "VIRTUALENV_WRAPPER_SOURCE=%~dp0%"
+
+path %VIRTUALENV_WRAPPER_SOURCE%scripts;%VIRTUALENV_WRAPPER_SOURCE%tests;%PATH%

--- a/scripts/mkvirtualenv.bat
+++ b/scripts/mkvirtualenv.bat
@@ -1,62 +1,173 @@
 @echo off
+:: Create a new environment, in the WORKON_HOME.
+::
+:: Syntax:
+:: 
+:: mkvirtualenv [-a project_path] [-i package] [-r requirements_file] [virtualenv options] %venvwrapper.envname%
+::
+:: All command line options except -a, -i, -r, and -h are passed directly 
+:: to virtualenv. The new environment is automatically activated after being
+:: initialized.
+::
+:: The -a option can be used to associate an existing project directory
+:: with the new environment.
+::
+:: The -i option can be used to install one or more packages (by repeating 
+:: the option) after the environment is created.
+::
+:: The -r option can be used to specify a text file listing packages to be 
+:: installed. The argument value is passed to pip -r to be installed.
+::
 
-if [%1]==[] goto USAGE
-goto MKVIRTUALENV
+:defaults
+    set "venvwrapper.original_args=%*"
+    set "venvwrapper.default_workon_home=%USERPROFILE%\Envs"
+    set "venvwrapper.scriptsdir=Scripts"
 
-:USAGE
-echo.
-echo.    Pass a name to create a new virtualenv
-goto END
+    :: make sure WORKON_HOME has a useful value
+    if not defined WORKON_HOME  set "WORKON_HOME=%venvwrapper.default_workon_home%"
+    set "venvwrapper.workon_home=%WORKON_HOME%"
 
-:MKVIRTUALENV
-if not defined WORKON_HOME (
-    set "WORKON_HOME=%USERPROFILE%\Envs"
+    if defined VIRTUALENV_EXECUTABLE (
+        set "venvwrapper.virtualenv_executable=%VIRTUALENV_EXECUTABLE%"
+    ) else (
+        set "venvwrapper.virtualenv_executable=virtualenv"
+    )
+
+:: print usage if no arguments given
+if [%1]==[] goto:usage
+
+
+setlocal 
+:: virtualenv options that take a paramter
+set "virualenv_param_options=-p --python --extra-search-dir --prompt"
+
+set /a debug=0
+:getopts
+    set /a ouropt=0
+    :: --debug and ---stop xxx should be first on the command line to get most effect
+    if [%1]==[---stop]  set "stop=%2" & shift & shift
+    if [%1]==[--debug] (
+        echo time: %TIME%
+        set /a ouropt=1
+        set /a debug=1
+        :: add verbose mode to virtualenv when in debug mode
+        set "venvargs=%venvargs% -v"
+    )
+    if [%1]==[-h]       goto:usage
+    if [%1]==[--help]   goto:usage
+
+    if [%1]==[-a] (
+        set /a ouropt=1
+        set "project_path=%2"
+        shift
+    )
+
+    if [%1]==[-r] (
+        set /a ouropt=1
+        set "requirements_file=%2"
+        shift
+    )
+
+    if [%1]==[-i] (
+        set /a ouropt=1
+        set "install_packages=%install_packages% %2"
+        shift
+    )
+
+    set "cur=%1"
+    :: is cur in virualenv_param_options?
+    call set filteredvar=%%virualenv_param_options:*%cur%=%%
+
+    if %ouropt% equ 0 (
+        if "%cur:~0,1%"=="-" (
+            :: starts with a dash (we found an option)
+            if not "%filteredvar%"=="%virualenv_param_options%" (
+                :: this is one of virtualenv's options that take a parameter
+                set "venvargs=%venvargs% %1=%2"
+                shift
+            ) else (
+                set "venvargs=%venvargs% %1"
+            )
+        ) else (
+            set "envname=%1"
+        )
+    )
+
+    shift
+    if not [%1]==[] goto:getopts
+(endlocal & rem export from setlocal block
+    set "venvwrapper.project_path=%project_path%"
+    set "venvwrapper.requirements_file=%requirements_file%"
+    set "venvwrapper.install_packages=%install_packages%"
+    set "venvwrapper.virtualenv_args=%venvargs%"
+    set "venvwrapper.envname=%envname%"
+    set "venvwrapper.stop=%stop%"
+    set /a venvwrapper.debug=%debug%
 )
 
+if %venvwrapper.debug% equ 1 (
+    echo ^<DEBUG options="%venvwrapper.original_args%"^>
+    set venvwrapper.
+    echo ^</DEBUG^>
+    if "%venvwrapper.stop%"=="after-argparse" goto:cleanup
+)
+
+if "%venvwrapper.envname%"=="" (
+    call :error_message You must specify a name for the virtualenv
+    call :cleanup
+    exit /b 1
+)
+
+:: exit any current virtualenv..
 if defined VIRTUAL_ENV (
-    call "%VIRTUAL_ENV%\Scripts\deactivate.bat" 
+    call "%VIRTUAL_ENV%\%venvwrapper.scriptsdir%\deactivate.bat" 
 )
 
-if defined PYTHONHOME (
-    set "PYHOME=%PYTHONHOME%"
-    goto MAIN
-)
-for /f "usebackq tokens=*" %%a in (`python.exe -c "import sys;print(sys.exec_prefix)"`) do (
-    set "PYHOME=%%a"
-)
 
-:MAIN
-REM Copy all arguments, then set ENVNAME to the last argument
-set "ARGS=%*"
-call :GET_ENVNAME %*
-
-pushd "%WORKON_HOME%" 2>NUL && popd
-if errorlevel 1 (
+if not exist "%WORKON_HOME%\*" (
+    echo. %WORKON_HOME% is not a directory, creating
+    :: try making it.. (let the user see any error messages)
     mkdir "%WORKON_HOME%"
+    if errorlevel 1 (
+        call :error_message couldn't create directory.
+        call :cleanup
+        exit /b 2
+    )
 )
 
-pushd "%WORKON_HOME%\%ENVNAME%" 2>NUL && popd
-if not errorlevel 1 (
-    echo.
-    echo.    virtualenv "%ENVNAME%" already exists
-    goto END
+:: make sure we know where the Scripts directory is located
+    if defined PYTHONHOME (
+        set "venvwrapper.pyhome=%PYTHONHOME%"
+    ) else (
+        for /f "usebackq tokens=*" %%a in (`python.exe -c "import sys;print(sys.exec_prefix)"`) do (
+            set "venvwrapper.pyhome=%%a"
+        )
+    )
+
+:: Check if venv exists (could be a file name, but don't care - still can't use it)
+if exist %WORKON_HOME%\%venvwrapper.envname% (
+    call :error_message virtualenv "%venvwrapper.envname%" already exists
+    call :cleanup
+    exit /b 3
 )
 
+if %venvwrapper.debug% equ 1 (
+    echo ^<DEBUG calling-virtualenv^>
+    set venvwrapper.
+    echo %venvwrapper.virtualenv_executable% %venvwrapper.virtualenv_args% %venvwrapper.envname%
+    echo ^</DEBUG^>
+    if "%venvwrapper.stop%"=="before-virtualenv" goto:cleanup
+)
+:: call virtualenv
 pushd "%WORKON_HOME%"
-REM As of Python 2.7, calling virtualenv.exe causes a new window to open,
-REM so call the script directly
-REM recent versions of virtualenv does not contain virtualenv-script.py..
-if exist "%PYHOME%\Scripts\virtualenv-script.py" (
-   python.exe "%PYHOME%\Scripts\virtualenv-script.py" %ARGS%
-) else (
-  virtualenv.exe %ARGS%
-)
+    %venvwrapper.virtualenv_executable% %venvwrapper.virtualenv_args% %venvwrapper.envname%
 popd
-if errorlevel 2 goto END
+if errorlevel 2 goto:cleanup
 
-REM In activate.bat, keep track of PYTHONPATH.
-REM This should be a change adopted by virtualenv.
->>"%WORKON_HOME%\%ENVNAME%\Scripts\activate.bat" (
+:: In activate.bat, keep track of PYTHONPATH.
+:: This should be a change adopted by virtualenv.
+>>"%WORKON_HOME%\%venvwrapper.envname%\Scripts\activate.bat" (
     echo.:: In case user makes changes to PYTHONPATH
     echo.if defined _OLD_VIRTUAL_PYTHONPATH (
     echo.    set "PYTHONPATH=%%_OLD_VIRTUAL_PYTHONPATH%%"
@@ -65,18 +176,28 @@ REM This should be a change adopted by virtualenv.
     echo.^)
 )
 
-REM In deactivate.bat, reset PYTHONPATH to its former value
->>"%WORKON_HOME%\%ENVNAME%\Scripts\deactivate.bat" (
+:: In deactivate.bat, reset PYTHONPATH to its former value
+>>"%WORKON_HOME%\%venvwrapper.envname%\Scripts\deactivate.bat" (
     echo.
     echo.if defined _OLD_VIRTUAL_PYTHONPATH (
     echo.    set "PYTHONPATH=%%_OLD_VIRTUAL_PYTHONPATH%%"
     echo.^)
 )
 
-call "%WORKON_HOME%\%ENVNAME%\Scripts\activate.bat"
+call "%WORKON_HOME%\%venvwrapper.envname%\Scripts\activate.bat"
 
-REM Run postmkvirtualenv.bat
+:: handle -a
+if not "%venvwrapper.project_path%"=="" call setprojectdir.bat "%venvwrapper.project_path%"
 
+:: handle -i (can be multiple)
+if not "%venvwrapper.install_packages%"=="" call :pipinstall "%venvwrapper.install_packages%"
+
+:: handle -r
+if not "%venvwrapper.requirements_file%"=="" (
+    call %VIRTUAL_ENV%\Scripts\pip install -r "%venvwrapper.requirements_file%"
+)
+
+:: Run postmkvirtualenv.bat
 if defined VIRTUALENVWRAPPER_HOOK_DIR (
     if exist "%VIRTUALENVWRAPPER_HOOK_DIR%\postmkvirtualenv.bat" (
     	call "%VIRTUALENVWRAPPER_HOOK_DIR%\postmkvirtualenv.bat"
@@ -84,14 +205,66 @@ if defined VIRTUALENVWRAPPER_HOOK_DIR (
 )
 
 
-goto END
+goto:cleanup
 
-:GET_ENVNAME
-  set "ENVNAME=%~1"
-  shift
-  if not "%~1"=="" goto GET_ENVNAME
-goto :eof
+:pipinstall
+    setlocal
+        set packages=%~1
+        for /F "tokens=1*" %%g in ("%packages%") do (
+            :: XXX should use --disable-pip-version-check (but only if pip version >= 6)
+            if not "%%g"=="" call %VIRTUAL_ENV%\Scripts\pip install %%g
+            if not "%%h"=="" call :pipinstall "%%h"
+        )
+    endlocal
+    goto:eof
 
-:END
-set PYHOME=
-set ENVNAME=
+:error_message
+    echo.
+    echo.    ERROR: %*
+    echo.
+    if %venvwrapper.debug% equ 1 (
+        echo ^<DEBUG error-message^>
+        echo %*
+        echo ^</DEBUG^>
+    )
+    goto:eof
+
+:debug_message
+    if %venvwrapper.debug% equ 1 (
+        echo ^<DEBUG message^>
+        echo %*
+        echo ^</DEBUG^>
+    )
+    goto:eof
+
+
+:usage
+    echo.
+    echo.Usage: mkvirtualenv [mkvirtualenv-options] [virtualenv-options] DEST_DIR
+    echo.
+    echo.  DEST_DIR              The name of the envirnment to create (must be last).
+    echo.
+    echo.The new environment is automatically activated after being
+    echo.initialized.
+    echo.
+    echo.mkvirtualenv options:
+    echo.  -a project_path       Associate existing path as project directory
+    echo.  -i package            Install package in new environment. This option
+    echo.                        can be repeated to install more than one package.
+    echo   -r requirements_file  requirements_file is passed to
+    echo.                        pip install -r requirements_file
+    echo.  
+    echo.    NOTE: all mkvirtualenv-options must come before virtualenv-options!
+    echo. 
+    echo.Options not specified above are passed to virtualenv:
+    echo.
+    echo %venvwrapper.virtualenv_executable% -h
+    call %venvwrapper.virtualenv_executable% -h
+    echo.
+    :: fall through
+
+:cleanup
+    if %venvwrapper.debug% equ 1  echo time: %TIME%
+    :: clear any variables that shouldn't escape
+    for /f "usebackq delims==" %%v in (`set venvwrapper.`) do @set "%%v="
+    goto:eof

--- a/scripts/setprojectdir.bat
+++ b/scripts/setprojectdir.bat
@@ -1,4 +1,6 @@
 @echo off
+set "__callingpath=%CALLINGPATH%"
+set "__projdir=%PROJDIR%"
 
 if [%1]==[] goto USAGE
 goto SETPROJECTDIR
@@ -44,5 +46,5 @@ set /p ="%PROJDIR%">"%VIRTUAL_ENV%\%VIRTUALENVWRAPPER_PROJECT_FILENAME%" <NUL
 call add2virtualenv.bat "%PROJDIR%"
 
 :END
-set CALLINGPATH=
-set PROJDIR=
+set "CALLINGPATH=%__callingpath%"
+set "PROJDIR=%__projdir%"

--- a/tests/_log.bat
+++ b/tests/_log.bat
@@ -1,0 +1,6 @@
+@echo off
+set config.log.output=%TMP%\config.log.output%RANDOM%.bat
+python -u _log.py %* > %config.log.output%
+call %config.log.output%
+del %config.log.output%
+set config.log.output=

--- a/tests/_log.py
+++ b/tests/_log.py
@@ -1,0 +1,72 @@
+"""
+Note: Output written to stdout will be executed in the parent shell.
+"""
+
+import sys
+import os
+import datetime
+import argparse
+
+
+def log(cmd, args, fname):
+    def logwrite(msg):
+        with open(fname, 'a') as fp:
+            fp.write(msg)
+
+    if cmd == 'begin':
+        logfilename = arg
+        with open(logfilename, 'w') as fp:
+            fp.write('start: %s\n' % datetime.datetime.now())
+        sys.stdout.write('set "config.logfile=%s"\n' % logfilename)
+
+    elif cmd == 'end':
+        logwrite('end: %s\n' % datetime.datetime.now())
+        with open(fname, 'r') as fp:
+            lines = fp.readlines()
+        logwrite(summary(lines))
+
+    elif cmd == 'summary':
+        with open(fname, 'r') as fp:
+            lines = fp.readlines()
+        logwrite(summary(lines))
+
+    elif cmd == 'read':
+        with open(fname, 'r') as fp:
+            sys.stderr.write(fp.read())
+
+    elif cmd == 'OK':
+        msg = '  >> OK   %s\n' % args
+        sys.stderr.write(msg)
+        logwrite(msg)
+
+    elif cmd == 'FAIL':
+        msg = '  >> FAIL %s\n' % args
+        sys.stderr.write(msg)
+        logwrite(msg)
+
+    else:
+        pass
+
+    return 0
+
+
+def summary(lines):
+    ok = fail = 0
+    ok = len([line for line in lines if line.startswith('  >> OK   ')])
+    fail = len([line for line in lines if line.startswith('  >> FAIL ')])
+    msg = "passing: %d  failing: %d:\n" % (ok, fail)
+    sys.stderr.write(msg)
+    sys.stdout.write('set /a config.passing_tests=%d\n' % ok)
+    sys.stdout.write('set /a config.failing_tests=%d\n' % fail)
+    return msg
+
+
+def main():
+    cmd = sys.argv[1]
+    msg = ' '.join(sys.argv[2:])
+    fname = os.environ['config.logfile']
+    return log(cmd, msg, fname)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/assertContains.bat
+++ b/tests/assertContains.bat
@@ -1,0 +1,2 @@
+@echo off
+python assertContains.py %*

--- a/tests/assertContains.py
+++ b/tests/assertContains.py
@@ -1,0 +1,38 @@
+
+import sys
+import os
+
+CURRENT_MODULE = os.environ['config.current_module']
+CURRENT_TEST = os.environ['config.current_test']
+
+
+def log(cmd, args=''):
+    os.system('_log %s %s:%s %s' % (
+        cmd,
+        CURRENT_MODULE,
+        CURRENT_TEST,
+        args
+    ))
+    return 0 if cmd == 'OK' else 1
+
+
+def assert_contains(fname, text, NOT=''):
+    """Returns True if ``text`` occurs in ``fname``.
+    """
+    with open(fname, 'rb') as fp:
+        contents = fp.read()
+        if NOT == 'NOT':
+            if text not in contents:
+                return log('OK', "didn't find [%s]" % text)
+            else:
+                return log('FAIL', 'found ' + text + ' in ' + contents)
+        else:
+            if text in contents:
+                return log('OK', 'found [%s]' % text)
+            else:
+                return log('FAIL', '[%s] not in %s' % (text, contents))
+
+
+if __name__ == "__main__":
+    # print 'SYS>ARGV', sys.argv
+    sys.exit(assert_contains(*sys.argv[1:]))

--- a/tests/assertEquals.bat
+++ b/tests/assertEquals.bat
@@ -10,11 +10,11 @@ if "%2" == "" (
 )
 
 if /I [%1]==[%2] (
-    echo.  ^>^> OK   %config.current_module%:%config.current_test%  1>&2
-    set /a config.passing_tests+=1
+    rem echo.  ^>^> OK   %config.current_module%:%config.current_test%  [%1] and [%2] are equal 1>&2
+    call _log OK %config.current_module%:%config.current_test%  [%1] and [%2] are equal
     exit /b 0
 ) else (
-    echo.  ^>^> FAIL %config.current_module%:%config.current_test%  [%1] and [%2] are not equal  1>&2
-    set /a config.failing_tests+=1
+    rem echo.  ^>^> FAIL %config.current_module%:%config.current_test%  [%1] and [%2] are not equal  1>&2
+    call _log FAIL %config.current_module%:%config.current_test%  [%1] and [%2] are not equal
     exit /b 1
 )

--- a/tests/assertExist.bat
+++ b/tests/assertExist.bat
@@ -1,0 +1,22 @@
+@echo off
+:: 
+::  verify that the two parameters are equal (case insensitively)
+::  provide the result on stderr
+::
+
+if "%1" == "" (
+    echo assertEquals requires a filename parameters^, got %*  1>&2
+    exit /b 99
+)
+
+if exist %1 (
+    rem echo.  ^>^> OK   %config.current_module%:%config.current_test%  [%1] exists 1>&2
+    call _log OK  %config.current_module%:%config.current_test%  [%1] exists
+    rem set /a config.passing_tests+=1
+    exit /b 0
+) else (
+    rem echo.  ^>^> FAIL %config.current_module%:%config.current_test%  [%1] does not exist  1>&2
+    call _log FAIL  %config.current_module%:%config.current_test%  [%1] does not exist 
+    rem set /a config.failing_tests+=1
+    exit /b 1
+)

--- a/tests/assertNotExist.bat
+++ b/tests/assertNotExist.bat
@@ -1,0 +1,18 @@
+@echo off
+:: 
+::  verify that the two parameters are equal (case insensitively)
+::  provide the result on stderr
+::
+
+if "%1" == "" (
+    echo assertEquals requires a filename parameters^, got %*  1>&2
+    exit /b 99
+)
+
+if not exist %1 (
+    call _log OK  %config.current_module%:%config.current_test%  [%1] does not exist
+    exit /b 0
+) else (
+    call _log FAIL   %config.current_module%:%config.current_test%  [%1] does exist  
+    exit /b 1
+)

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -27,6 +27,7 @@ setlocal enableDelayedExpansion
 
 :: go to tests directory
 pushd %~dp0
+    call _log begin logfile.txt
     pushd ..
         :: add the source and tests directories to the path
         path %CD%\scripts;%CD%\tests;%PATH%
@@ -49,6 +50,11 @@ pushd %~dp0
     )
 
 popd
+
+call _log end
+
+exit /b %config.failing_tests%
+
 goto:eof
 
 

--- a/tests/test_cd.bat
+++ b/tests/test_cd.bat
@@ -1,6 +1,7 @@
 
+
 :setup
-    call mkvirtualenv cd-test
+    call mkvirtualenv cd-test --no-download --no-wheel --no-setuptools --no-pip
 
 
 call _start_test cdvirtualenv

--- a/tests/test_example.bat
+++ b/tests/test_example.bat
@@ -2,7 +2,7 @@
 ::
 ::  sample test file
 ::
-
+goto:eof
 :: the test files are run from run_tests.bat
 
 rem first call setup.bat to define the testing environment %1 is the current

--- a/tests/test_mkvirtualenv.bat
+++ b/tests/test_mkvirtualenv.bat
@@ -1,0 +1,94 @@
+
+set config.output=%TMP%\output%config.unique%
+mkdir %config.output%
+
+call _start_test argparse_empty
+    :: check that we don't set a envname when one is not provided
+    set fname=%config.output%\%config.current_test%.output
+    call mkvirtualenv  --debug ---stop after-argparse  > %fname%
+    call assertContains %fname% venvwrapper.envname NOT
+
+
+call _start_test argparse_envname
+    :: check simple case, only envname (and debug args of course)
+    set fname=%config.output%\%config.current_test%.output
+    call mkvirtualenv  --debug ---stop after-argparse  foo > %fname%
+    call assertContains %fname% venvwrapper.envname=foo
+
+call _start_test argparse_pass_flags
+    :: check that a flag is passed through to virtualenv (--debug adds -v)
+    set fname=%config.output%\%config.current_test%.output
+    call mkvirtualenv  --debug ---stop after-argparse  foo --no-download > %fname%
+    call assertContains %fname% "venvwrapper.virtualenv_args= -v --no-download"
+
+call _start_test argparse_pass_flags
+    :: check that a parameter with value is passed through to virtualenv (--debug adds -v)
+    set fname=%config.output%\%config.current_test%.output
+    call mkvirtualenv  --debug ---stop after-argparse  foo --extra-search-dir=c:\wheelhouse > %fname%
+    call assertContains %fname% "venvwrapper.virtualenv_args= -v --extra-search-dir=c:\wheelhouse"
+
+
+call _start_test mkvirtualenv_r
+    set fname=%config.output%\%config.current_test%.output
+    > %fname%.requirements (
+        echo.virtualenv-clone
+        echo.
+    )
+    echo requirements file: "%fname%.requirements"
+    type %fname%.requirements
+    pushd .
+        call mkvirtualenv venv_r -r %fname%.requirements --no-download --no-wheel --no-setuptools
+    popd
+    call %VIRTUAL_ENV%\Scripts\pip freeze > %fname%.pipfreeze
+    echo fname [%fname%.pipfreeze] contents:
+    type %fname%.pipfreeze
+    call assertContains "%fname%.pipfreeze" "virtualenv-clone"
+
+
+call _start_test mkvirtualenv_i
+    set fname=%config.output%\%config.current_test%.output
+    pushd .
+        call mkvirtualenv venv_i -i virtualenv-clone -i virtualenv-api --no-download --no-wheel --no-setuptools
+    popd
+    call %VIRTUAL_ENV%\Scripts\pip freeze > %fname%.pipfreeze
+    echo fname [%fname%.pipfreeze] contents:
+    type %fname%.pipfreeze
+    call assertContains "%fname%.pipfreeze" "virtualenv-clone"
+    call assertContains "%fname%.pipfreeze" "virtualenv-api"
+
+
+call _start_test mkvirtualenv_a
+    set fname=%config.output%\%config.current_test%.output
+    set projdir=%config.output%\venv_a_projdir
+    echo making project directory [%projdir%]
+    mkdir "%projdir%"
+    call assertExist "%projdir%"
+    pushd .
+        call mkvirtualenv venv_a -a %projdir% --no-download --no-wheel --no-setuptools --no-pip
+    popd
+    call assertExist %VIRTUAL_ENV%\.project
+    set /p env_projdir=<%VIRTUAL_ENV%\.project
+    call assertEquals "%env_projdir%" "%projdir%"
+
+
+call _start_test make_simple_env
+    call mkvirtualenv simpleenv --no-download --no-wheel --no-setuptools --no-pip
+    call assertExist %VIRTUAL_ENV%\Scripts\python.exe
+    call assertNotExist %VIRTUAL_ENV%\Scripts\pip.exe
+    call assertNotExist %VIRTUAL_ENV%\Scripts\wheel.exe
+    echo %PROMPT% > %fname%.prompt
+    call assertContains %fname%.prompt "(simpleenv)"
+
+
+call _start_test make_default_env
+    call mkvirtualenv defaultenv
+    :: dir %VIRTUAL_ENV%\Scripts
+    call assertExist %VIRTUAL_ENV%\Scripts\python.exe
+    call assertExist %VIRTUAL_ENV%\Scripts\pip.exe
+    call assertExist %VIRTUAL_ENV%\Scripts\wheel.exe
+    echo %PROMPT% > %fname%.prompt
+    call assertContains %fname%.prompt "(defaultenv)"
+
+
+:cleanup
+    ::rmdir %config.output% /s/q 


### PR DESCRIPTION
`--debug` and `---stop target` are also added to help with debugging and
testing.

Any other options are handed off to `virtualenv`.

This solves #60, part of #67 (`mkvirtualenv` without parameters is now the same as `mkvirtualenv -h`), and
#68.
