### PR TITLE
Add invoke tasks.py file to make it easier to publish to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Include
 Lib
 virtualenvwrapper_win.egg-info
 tests/logfile.txt
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@
 Changes
 -------
 
+Version 1.2.3
+=====================================
+* Fixed a problem when the WORKON_HOME folder contained spaces.
+* Fixed a bug where cmd.com couldn't pass the Python executable to virtualenv
+  if the path included the drive letter.
+* Improved publish pipeline.
+
 Version 1.2.2
 =====================================
 *   -a, -i, and -r options are now available (@thebjorn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# these are requirements for developing/testing/releasing virtualenvwrapper-win
+
+virtualenv==15.1.0
+invoke==0.20.3
+twine==1.9.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = 'David Marble'
 EMAIL = 'davidmarble@gmail.com'
 DESCRIPTION = ('Port of Doug Hellmann\'s virtualenvwrapper '
                'to Windows batch scripts')
-VERSION = '1.2.2'
+VERSION = '1.2.3'
 PROJECT_URL = 'https://github.com/davidmarble/%s/' % (PROJECT)
 scripts_loc = 'scripts/'
 scripts = [

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+This file defines tasks for the Invoke tool: http://www.pyinvoke.org
+
+Basic usage::
+
+    inv -l               # list all available tasks
+    inv --help task      # show help for task
+
+"""
+# pragma: nocover
+from __future__ import print_function
+import os
+import re
+import sys
+import invoke
+
+DIRNAME = os.path.dirname(__file__)
+
+# unfortunately invoke is currently a bit broken on windows..
+try:
+    from invoke import ctask as _task
+except ImportError:
+    from invoke import task as _task
+
+if invoke.__version_info__ < (0, 22):
+    _should_patch = True
+elif invoke.__version_info__ < (0, 22 + 22-13):  # broken since 13..
+    from invoke import run as _run
+    try:
+        _run('rem')
+        _should_patch = False
+    except WindowsError:
+        _should_patch = True
+
+
+if _should_patch:
+    # https://github.com/pyinvoke/invoke/pull/407
+    from invoke import Context
+
+    if not getattr(Context, '_patched', False):
+        Context._patched = True
+        _orig_run = Context.run
+
+        def run(self, command, **kwargs):
+            if sys.platform == 'win32':
+                kwargs['shell'] = os.environ['COMSPEC']
+            return _orig_run(self, command, **kwargs)
+
+        Context.run = run
+
+task = _task
+
+
+@task
+def version(ctx):
+    """Print the current version number.
+    """
+    os.chdir(DIRNAME)
+    ctx.run('python setup.py --version')
+
+
+@task
+def setversion(ctx, version):
+    """Set the version number
+    """
+    os.chdir(DIRNAME)
+    with open('setup.py', 'rb') as fp:
+        txt = fp.read()
+
+    with open('setup.py', 'wb') as fp:
+        fp.write(re.sub(
+            r'^VERSION\s*=\s*.*?$', "VERSION = '%s'" % version,
+            txt,
+            flags=re.MULTILINE
+        ))
+    print("Changed version in setup.py to:", version)
+
+
+@task(
+    help={
+        'clean': 'remove the dist/ directory before starting',
+        'wheel': 'build wheel (in addition to sdist)',
+        'upload': 'upload to PyPI after building'
+    }
+)
+def build(ctx, clean=False, wheel=True, upload=False):
+    """Build and publish (inv --help build for details)
+    """
+    os.chdir(DIRNAME)
+    if clean:
+        ctx.run('rmdir dist /s /q')
+
+    targets = 'sdist'
+    if wheel:
+        targets += ' bdist_wheel'
+    ctx.run("python setup.py " + targets)
+    # ctx.run("python setup.py build_sphinx")
+    if upload:
+        ctx.run("twine upload dist/*")
+
+
+# individual tasks that can be run from this project
+ns = invoke.Collection(
+    version,
+    setversion,
+    build
+)
+ns.configure({
+    'run': {
+        'echo': True
+    }
+})

--- a/tasks.py
+++ b/tasks.py
@@ -79,7 +79,7 @@ def setversion(ctx, version):
 
 @task(
     help={
-        'clean': 'remove the dist/ directory before starting',
+        'clean': 'remove the build/ and dist/ directory before starting',
         'wheel': 'build wheel (in addition to sdist)',
         'upload': 'upload to PyPI after building'
     }
@@ -90,6 +90,7 @@ def build(ctx, clean=False, wheel=True, upload=False):
     os.chdir(DIRNAME)
     if clean:
         ctx.run('rmdir dist /s /q')
+        ctx.run('rmdir build /s /q')
 
     targets = 'sdist'
     if wheel:


### PR DESCRIPTION
Basic usage:

 - pip install -r requirements.txt (to get invoke and twine)
 - `inv -l` to list available tasks
 - `inv version` to print current version
 - `inv setversion 1.2.3` to set the version to 1.2.3.
 - `inv build --clean --upload` to remove build/dist directories, build sdist and wheels, and finally use twine to upload to PyPI.