### PR TITLE
Added mkproject script (with better default PROJECT_HOME) to setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@
 Changes
 -------
 
+Version 1.2.4
+=====================================
+* Added mkproject convenience script
+
 Version 1.2.3
 =====================================
 * Fixed a problem when the WORKON_HOME folder contained spaces.

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,11 @@ Convenience Commands
     the site-packages directory, the contents of easy-install.pth,
     and the contents of virtualenv_path_extensions.pth (used by
     ``add2virtualenv``).
+	
+``mkproject``
+	If the environment variable PROJECT_HOME is set, create a new project 
+	directory in PROJECT_HOME and a virtualenv in WORKON_HOME.  The project path
+	will automatically be associated with the virtualenv on creation.
 
 ``setprojectdir <full or relative path>``
     If a virtualenv environment is active, define *<path>* as project

--- a/scripts/mkproject.bat
+++ b/scripts/mkproject.bat
@@ -18,7 +18,7 @@ goto END
 
 :MKPROJECT
 if not defined PROJECT_HOME (
-    set "PROJECT_HOME=%USERPROFILE%\.projects"
+    set "PROJECT_HOME=%USERPROFILE%\Projects"
 )
 
 pushd %PROJECT_HOME% 2>NUL && popd

--- a/scripts/mkproject.bat
+++ b/scripts/mkproject.bat
@@ -1,53 +1,61 @@
 @echo off
+:: Convenience script to create a project directory and an associated virtualenv
+::
+:: Syntax:
+:: 
+:: mkproject PROJ_DIR
+::
 
-if [%1]==[] goto USAGE
-goto MKVIRTUALENV
-
-
-:USAGE
-echo.
-echo.    Pass a name to create a new virtualenv and linked project
-goto END
-
-
-:LINKPROJECT
-call setprojectdir.bat "%PROJ%"
-call cdproject.bat
-goto END
-
-
-:MKPROJECT
-if not defined PROJECT_HOME (
-    set "PROJECT_HOME=%USERPROFILE%\Projects"
+:: print usage if no arguments given otherwise make a local variable to point at the expected project folder
+if [%1]==[] (
+	goto:usage
+) else (
+	set "PROJ_DIR=%PROJECT_HOME%\%1"
 )
 
+:: the environment variable PROJECT_HOME must be set for this script to work
+if not defined PROJECT_HOME (
+    call :error_message set environment variable PROJECT_HOME to the directory where projects are stored.
+)
+	
+:: test if PROJECT_HOME exists (supporting network paths)
 pushd %PROJECT_HOME% 2>NUL && popd
+:: create it if it doesn't exist
 if errorlevel 1 (
     mkdir %PROJECT_HOME%
 )
 
-set "PROJ=%PROJECT_HOME%\%1"
-
-pushd %PROJ% 2>NUL && popd
+:: test if PROJ_DIR exists (supporting network paths)
+pushd "%PROJ_DIR%" 2>NUL && popd
+:: create it if it doesn't exist and throw an error if it does
 if errorlevel 1 (
-    mkdir %PROJ%
-    goto LINKPROJECT
+    mkdir %PROJ_DIR%
 ) else (
+	call :error_message project %PROJ_DIR% already exists
+)
+
+:: use mkvirtualenv to create the environment and link it to the project folder
+call mkvirtualenv -a %PROJ_DIR% %1
+
+:: move to the project directory
+call cdproject
+
+:: clean up and exit
+goto:cleanup
+
+:error_message
     echo.
-    echo.    project "%PROJ%" already exists
-    goto END
-)
+    echo.    ERROR: %*
+    echo.
+	goto:cleanup
 
-
-:MKVIRTUALENV
-call mkvirtualenv.bat %1
-
-if not defined VIRTUAL_ENV (
-    goto END
-)
-
-goto MKPROJECT
-
-
-:END
-set PROJ=
+:usage
+	echo.Usage:	mkproject PROJ_DIR
+    echo.
+    echo.  PROJ_DIR			The name of the project/envirnment to create.
+    echo.
+    echo.The new environment is automatically activated after being initialized.
+	:: fall through
+	
+:cleanup
+	set PROJ_DIR=

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ scripts = [
     'folder_delete.bat',
     'lssitepackages.bat',
     'lsvirtualenv.bat',
+	'mkproject.bat',
     'mkvirtualenv.bat',
     'rmvirtualenv.bat',
     'setprojectdir.bat',


### PR DESCRIPTION
Previously I had replicated the mkproject functionality from the main virtualenvwrapper repo but the batch script was not being installed by setup.py as I hadn't added it there.  This fixes that omission.

Also I've brought the default project directory (PROJECT_HOME) in line with the default WORKON_HOME