### PR TITLE
Add powershell scripts for workon and cdproject

### DIFF
--- a/scripts/cdproject.ps1
+++ b/scripts/cdproject.ps1
@@ -1,0 +1,32 @@
+function Show-Usage {
+    echo ""
+    echo  "switches to the project dir of the activated virtualenv"
+}
+
+if (-not (Test-Path env:VIRTUAL_ENV)) {
+    echo ""
+    echo "a virtualenv must be activated"
+    Show-Usage
+    return
+}
+
+if (-not (Test-Path env:VIRTUALENVWRAPPER_PROJECT_FILENAME)) {
+    $VIRTUALENVWRAPPER_PROJECT_FILENAME = '.project'
+} else {
+    $VIRTUALENVWRAPPER_PROJECT_FILENAME = ($env:VIRTUALENVWRAPPER_PROJECT_FILENAME).Replace('"','')
+}
+
+if (-not (Test-Path "$($env:VIRTUAL_ENV)\$($VIRTUALENVWRAPPER_PROJECT_FILENAME)")) {
+    echo ""
+    echo "No project directory found for current virtualenv"
+    Show-Usage
+    return
+}
+
+
+$ENVPRJDIR = Get-Content "$($env:VIRTUAL_ENV)\$($VIRTUALENVWRAPPER_PROJECT_FILENAME)" -First 1
+
+# If path extracted from file contains env variables, the system will not find the path.
+# TODO: Add this functionality
+
+cd $ENVPRJDIR

--- a/scripts/workon.ps1
+++ b/scripts/workon.ps1
@@ -1,0 +1,40 @@
+if (-not (Test-Path env:WORKON_HOME))
+{
+    $WORKON_HOME = '~\Envs'
+} else {
+    $WORKON_HOME = ($env:WORKON_HOME).Replace('"','')
+}
+
+if (-not (Test-Path env:VIRTUALENVWRAPPER_PROJECT_FILENAME)) {
+    $VIRTUALENVWRAPPER_PROJECT_FILENAME = '.project'
+} else {
+    $VIRTUALENVWRAPPER_PROJECT_FILENAME = ($env:VIRTUALENVWRAPPER_PROJECT_FILENAME).Replace('"','')
+}
+
+if ($args.length -eq 0) {
+    echo "Pass a name to activate one of the following virtualenvs:"
+    echo ==============================================================================
+    (Get-ChildItem -Path $WORKON_HOME).Name
+    return
+}
+
+$VENV = $args[0]
+
+if (!(Test-Path -Path ("$($WORKON_HOME)\$($VENV)"))) {
+    echo ("virtualenv $($VENV) does not exist")
+    echo "Create it with 'mkvirtualenv $($VENV)'"
+    return
+}
+
+if (!(Test-Path -Path ("$($WORKON_HOME)\$($VENV)\Scripts\activate.ps1") ))  {
+    echo "$($WORKON_HOME)$($VENV)"
+    echo "doesn't contain a virtualenv (yet)."
+    echo "Create it with 'mkvirtualenv $($VENV)'"
+    return
+}
+
+iex ("$($WORKON_HOME)\$($VENV)\Scripts\activate.ps1")
+
+if (Test-Path -Path ("$($WORKON_HOME)\$($VENV)\$($VIRTUALENVWRAPPER_PROJECT_FILENAME)")) {
+    iex "cdproject"
+}

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ scripts = [
     'add2virtualenv.bat',
     'cd-.bat',
     'cdproject.bat',
+    'cdproject.ps1',
     'cdsitepackages.bat',
     'cdvirtualenv.bat',
     'folder_delete.bat',
@@ -27,6 +28,7 @@ scripts = [
     'toggleglobalsitepackages.bat',
     'whereis.bat',
     'workon.bat',
+    'workon.ps1',
     'virtualenvwrapper.bat',
     'vwenv.bat',
 ]


### PR DESCRIPTION
Currently, the workon and cdproject scripts can be called only from the native command prompt. Creating equivalent powershell scripts solves this, since the powershell script overrides the batch script in powershell and the batch executes as expected in cmd.
Note: Some things are still left to do