### PR TITLE
Solve lack of wheel bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
 
     scripts=[scripts_loc + script for script in scripts],
 
-    install_requires=['virtualenv', ],
+    install_requires=['virtualenv', 'wheel'],
 
     # extras
     # pywin==0.2


### PR DESCRIPTION
Wheel is an important requirement. If it is missing, the installation of virtualenvwrapper-win fails.