### PR TITLE
Change "call" to "cmd /K" in workon.bat

### DIFF
--- a/scripts/workon.bat
+++ b/scripts/workon.bat
@@ -58,7 +58,7 @@ if not exist "%WORKON_HOME%\%VENV%\Scripts\activate.bat" (
     goto END
 )
 
-call "%WORKON_HOME%\%VENV%\Scripts\activate.bat"
+cmd /K  "%WORKON_HOME%\%VENV%\Scripts\activate.bat"
 if defined WORKON_OLDTITLE (
     title %1 ^(VirtualEnv^)
 )


### PR DESCRIPTION
For some reason, workon did not execute activate.bat when working with pyenv-win. Path was resolved correctly, but for some reason the called script had no effect. I'm not sure what broke it, might be the fact that I work across multiple drives, but this change fixed it.