### PR TITLE
Run virtualenv as a script

### DIFF
--- a/scripts/mkvirtualenv.bat
+++ b/scripts/mkvirtualenv.bat
@@ -172,7 +172,7 @@ if %venvwrapper.debug% equ 1 (
 )
 :: call virtualenv
 pushd "%WORKON_HOME%"
-    "%venvwrapper.virtualenv_executable%" %venvwrapper.virtualenv_args% %venvwrapper.envname% --prompt="%venvwrapper.quoteless_envname%"
+    py -m "%venvwrapper.virtualenv_executable%" %venvwrapper.virtualenv_args% %venvwrapper.envname% --prompt="%venvwrapper.quoteless_envname%"
 popd
 if errorlevel 2 goto:cleanup
 


### PR DESCRIPTION
run virtualenv as a script

fix the error I was facing with python3.10 :
 `"virtualenv"' is not recognized as an internal or external command`